### PR TITLE
Add capability to filter test executables with runsettings configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ Test
 ====
 The Adapter is tested against the Solution in [CatchUnitTestRef](https://github.com/xkbeyer/CatchUnitTestRef)
 
+Settings
+========
+You can configure the adapter by adding a `CatchAdapter` element to your .runsettings file.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <!-- Catch adapter -->
+  <CatchAdapter>
+    <!-- Regexes one of which must match an executable's name
+         for tests to be searched from it. -->
+    <TestExeInclude>
+      <Regex>.*\.Test\.exe</Regex>
+    </TestExeInclude>
+    <!-- If one of these regexes matches, the exe is excluded
+         even if it matches an include. -->
+    <TestExeExclude>
+      <Regex>Cheese</Regex>
+    </TestExeExclude>
+  </CatchAdapter>
+</RunSettings>
+```
+
 TODO
 ====
 - More tests in ReferenceCatchProject (may be combined with the test repo).

--- a/TestAdapter/Settings/CatchAdapterSettings.cs
+++ b/TestAdapter/Settings/CatchAdapterSettings.cs
@@ -16,7 +16,7 @@ namespace TestAdapter.Settings
     /// Found as the element "Catch" in a Visual Studio runsettings xml file.
     /// </summary>
     [XmlRoot(XmlRoot)]
-    class CatchAdapterSettings : TestRunSettings
+    public class CatchAdapterSettings : TestRunSettings
     {
         /// <summary>
         /// The name of the XML that holds these settings.

--- a/TestAdapter/Settings/CatchAdapterSettings.cs
+++ b/TestAdapter/Settings/CatchAdapterSettings.cs
@@ -21,7 +21,7 @@ namespace TestAdapter.Settings
         /// <summary>
         /// The name of the XML that holds these settings.
         /// </summary>
-        public const string XmlRoot = "Catch";
+        public const string XmlRoot = "CatchAdapter";
 
         public CatchAdapterSettings(): base( XmlRoot ) { }
 

--- a/TestAdapter/Settings/CatchAdapterSettings.cs
+++ b/TestAdapter/Settings/CatchAdapterSettings.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace TestAdapter.Settings
+{
+    /// <summary>
+    /// Settings for the catch test adapter.
+    /// Found as the element "Catch" in a Visual Studio runsettings xml file.
+    /// </summary>
+    [XmlRoot(XmlRoot)]
+    class CatchAdapterSettings : TestRunSettings
+    {
+        /// <summary>
+        /// The name of the XML that holds these settings.
+        /// </summary>
+        public const string XmlRoot = "Catch";
+
+        public CatchAdapterSettings(): base( XmlRoot ) { }
+
+        #region Settings
+
+        /// <summary>
+        /// Regex used to find test executables.
+        /// </summary>
+        [DefaultValue( @".*\.exe" )]
+        public string TestExeFilter { get; set; } = @".*\.exe";
+
+        #endregion
+
+        #region Interpretations
+
+        /// <summary>
+        /// Returns true if the given executable should be treated as a source of tests.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public bool IncludeTestExe( string name )
+        {
+            return Regex.Match( name, this.TestExeFilter ).Success;
+        }
+
+        #endregion Interpretations
+
+        public override XmlElement ToXml()
+        {
+            // Create a temporary Xml document.
+            XmlDocument doc = new XmlDocument();
+
+            // Write the settings to it.
+            using ( var writer = doc.CreateNavigator().AppendChild() )
+            {
+                var serializer = new XmlSerializer( typeof( CatchAdapterSettings ) );
+                serializer.Serialize( writer, this );
+            }
+
+            // Because the element is a root in the temporary document,
+            // some root specific elements were automatically added to it,
+            // but it won't actually be a root where we want it, so we remove them.
+            doc.DocumentElement.RemoveAllAttributes();
+
+            return doc.DocumentElement;
+        }
+    }
+}

--- a/TestAdapter/Settings/CatchAdapterSettings.cs
+++ b/TestAdapter/Settings/CatchAdapterSettings.cs
@@ -30,8 +30,16 @@ namespace TestAdapter.Settings
         /// <summary>
         /// Regex used to find test executables.
         /// </summary>
-        [DefaultValue( @".*\.exe" )]
-        public string TestExeFilter { get; set; } = @".*\.exe";
+        [XmlArray( "TestExeInclude" )]
+        [XmlArrayItem( "Regex" )]
+        public List<string> TestExeInclude { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Regex used to exclude test executables.
+        /// </summary>
+        [XmlArray( "TestExeExclude" )]
+        [XmlArrayItem( "Regex" )]
+        public List<string> TestExeExclude { get; set; } = new List<string>();
 
         #endregion
 
@@ -44,7 +52,15 @@ namespace TestAdapter.Settings
         /// <returns></returns>
         public bool IncludeTestExe( string name )
         {
-            return Regex.Match( name, this.TestExeFilter ).Success;
+            // If there are include patterns, the name must match one of them.
+            if( this.TestExeInclude.Count > 0 )
+            {
+                if ( !TestExeInclude.Any( regex => Regex.IsMatch( name, regex ) ) )
+                    return false;
+            }
+
+            // The name must not match any exclude pattern.
+            return !this.TestExeExclude.Any( regex => Regex.IsMatch( name, regex ) );
         }
 
         #endregion Interpretations

--- a/TestAdapter/Settings/CatchSettingsProvider.cs
+++ b/TestAdapter/Settings/CatchSettingsProvider.cs
@@ -16,7 +16,7 @@ namespace TestAdapter.Settings
     /// </summary>
     [Export( typeof( ISettingsProvider ) )]
     [SettingsName( CatchAdapterSettings.XmlRoot )]
-    class CatchSettingsProvider : ISettingsProvider
+    public class CatchSettingsProvider : ISettingsProvider
     {
         /// <summary>
         /// Stored the last loaded settings, if any.

--- a/TestAdapter/Settings/CatchSettingsProvider.cs
+++ b/TestAdapter/Settings/CatchSettingsProvider.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using System.Xml.Serialization;
+
+namespace TestAdapter.Settings
+{
+    /// <summary>
+    /// SettingsProvider used to register our interest in the "Catch" node.
+    /// </summary>
+    [Export( typeof( ISettingsProvider ) )]
+    [SettingsName( CatchAdapterSettings.XmlRoot )]
+    class CatchSettingsProvider : ISettingsProvider
+    {
+        /// <summary>
+        /// Stored the last loaded settings, if any.
+        /// </summary>
+        public CatchAdapterSettings Settings { get; set; }
+
+        /// <summary>
+        /// Load the settings from xml.
+        /// </summary>
+        /// <param name="reader">Reader pointed at the root node of the adapter settings node.</param>
+        public void Load( XmlReader reader )
+        {
+            // Check that the node is correct.
+            if(reader.Read() && reader.Name == CatchAdapterSettings.XmlRoot )
+            {
+                // Deserialize the settings.
+                var deserializer = new XmlSerializer( typeof(CatchAdapterSettings) );
+                this.Settings = deserializer.Deserialize( reader ) as CatchAdapterSettings;
+            }
+        }
+
+        /// <summary>
+        /// Loads settings from the runsettings in the discovery context.
+        /// Returns default settings otherwise.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static CatchAdapterSettings LoadSettings(IDiscoveryContext context )
+        {
+            CatchAdapterSettings settings = new CatchAdapterSettings();
+
+            if( context.RunSettings != null )
+            {
+                var provider = context.RunSettings.GetSettings( CatchAdapterSettings.XmlRoot ) as CatchSettingsProvider;
+                if( provider != null && provider.Settings != null )
+                {
+                    settings = provider.Settings;
+                }
+            }
+
+            return settings;
+        }
+    }
+}

--- a/TestAdapter/Settings/CatchSettingsProvider.cs
+++ b/TestAdapter/Settings/CatchSettingsProvider.cs
@@ -44,13 +44,13 @@ namespace TestAdapter.Settings
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
-        public static CatchAdapterSettings LoadSettings(IDiscoveryContext context )
+        public static CatchAdapterSettings LoadSettings(IRunSettings runSettings )
         {
             CatchAdapterSettings settings = new CatchAdapterSettings();
 
-            if( context.RunSettings != null )
+            if( runSettings != null )
             {
-                var provider = context.RunSettings.GetSettings( CatchAdapterSettings.XmlRoot ) as CatchSettingsProvider;
+                var provider = runSettings.GetSettings( CatchAdapterSettings.XmlRoot ) as CatchSettingsProvider;
                 if( provider != null && provider.Settings != null )
                 {
                     settings = provider.Settings;

--- a/TestAdapter/TestAdapter.csproj
+++ b/TestAdapter/TestAdapter.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Collections.Immutable, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.2.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Reflection.Metadata, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.1.3.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
@@ -56,9 +57,12 @@
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Serialization" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ProcessRunner.cs" />
+    <Compile Include="Settings\CatchAdapterSettings.cs" />
+    <Compile Include="Settings\CatchSettingsProvider.cs" />
     <Compile Include="TestExecutor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestDiscoverer.cs" />

--- a/TestAdapter/TestDiscoverer.cs
+++ b/TestAdapter/TestDiscoverer.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 using System.Text.RegularExpressions;
 using System.Linq;
+using TestAdapter.Settings;
 
 namespace CatchTestAdapter
 {
@@ -16,8 +17,12 @@ namespace CatchTestAdapter
         public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
         {
             logger.SendMessage(TestMessageLevel.Informational, "Catch Discover in process ...");
+
+            // Load settings from the discovery context.
+            CatchAdapterSettings settings = CatchSettingsProvider.LoadSettings( discoveryContext );
+
             //System.Diagnostics.Debugger.Launch();
-            foreach (var src in sources)
+            foreach (var src in sources.Where( src => settings.IncludeTestExe(src) ))
             {
                 var testCases = CreateTestCases(src);
                 foreach (var t in testCases)

--- a/TestAdapter/TestDiscoverer.cs
+++ b/TestAdapter/TestDiscoverer.cs
@@ -19,7 +19,7 @@ namespace CatchTestAdapter
             logger.SendMessage(TestMessageLevel.Informational, "Catch Discover in process ...");
 
             // Load settings from the discovery context.
-            CatchAdapterSettings settings = CatchSettingsProvider.LoadSettings( discoveryContext );
+            CatchAdapterSettings settings = CatchSettingsProvider.LoadSettings( discoveryContext.RunSettings );
 
             //System.Diagnostics.Debugger.Launch();
             foreach (var src in sources.Where( src => settings.IncludeTestExe(src) ))

--- a/TestAdapter/TestDiscoverer.cs
+++ b/TestAdapter/TestDiscoverer.cs
@@ -24,6 +24,8 @@ namespace CatchTestAdapter
             //System.Diagnostics.Debugger.Launch();
             foreach (var src in sources.Where( src => settings.IncludeTestExe(src) ))
             {
+                logger.SendMessage( TestMessageLevel.Informational, $"Processing catch test source: '{src}'..." );
+
                 var testCases = CreateTestCases(src);
                 foreach (var t in testCases)
                 {

--- a/TestAdapter/TestExecutor.cs
+++ b/TestAdapter/TestExecutor.cs
@@ -8,6 +8,8 @@ using System.Xml.Linq;
 using System.Globalization;
 using System.Diagnostics;
 
+using TestAdapter.Settings;
+
 namespace CatchTestAdapter
 {
     [ExtensionUri(ExecutorUriString)]
@@ -23,10 +25,14 @@ namespace CatchTestAdapter
 
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
-            frameworkHandle.SendMessage(TestMessageLevel.Informational, "RunTest with source " + sources.First());
-            foreach(var exeName in sources)
+            // Load settings from the context.
+            var settings = CatchSettingsProvider.LoadSettings( runContext.RunSettings );
+
+            // Run tests in all included executables.
+            foreach(var exeName in sources.Where(name => settings.IncludeTestExe(name) ) )
             {
-                var  tests = TestDiscoverer.CreateTestCases(exeName);
+                frameworkHandle.SendMessage( TestMessageLevel.Informational, "RunTest with source " + sources.First() );
+                var tests = TestDiscoverer.CreateTestCases( exeName );
                 RunTests(tests, runContext, frameworkHandle);
             }
         }

--- a/TestAdapterTest/Mocks/MockDiscoveryContext.cs
+++ b/TestAdapterTest/Mocks/MockDiscoveryContext.cs
@@ -15,8 +15,10 @@ namespace TestAdapterTest.Mocks
         {
             get
             {
-                throw new NotImplementedException();
+                return this.MockSettings;
             }
         }
+
+        public MockRunSettings MockSettings { get; set; } = new MockRunSettings();
     }
 }

--- a/TestAdapterTest/Mocks/MockRunContext.cs
+++ b/TestAdapterTest/Mocks/MockRunContext.cs
@@ -22,11 +22,13 @@ namespace TestAdapterTest.Mocks
 
         public string SolutionDirectory => throw new NotImplementedException();
 
-        public IRunSettings RunSettings => throw new NotImplementedException();
+        public IRunSettings RunSettings => this.MockSettings;
 
         public ITestCaseFilterExpression GetTestCaseFilter( IEnumerable<string> supportedProperties, Func<string, TestProperty> propertyProvider )
         {
             throw new NotImplementedException();
         }
+
+        public MockRunSettings MockSettings { get; set; } = new MockRunSettings();
     }
 }

--- a/TestAdapterTest/Mocks/MockRunSettings.cs
+++ b/TestAdapterTest/Mocks/MockRunSettings.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestAdapterTest.Mocks
+{
+    class MockRunSettings : IRunSettings
+    {
+        public string SettingsXml => throw new NotImplementedException();
+
+        public ISettingsProvider GetSettings( string settingsName )
+        {
+            return this.Provider;
+        }
+
+        public ISettingsProvider Provider { get; set; }
+    }
+}

--- a/TestAdapterTest/ReferenceCatchProject/ReferenceCatchProject.vcxproj
+++ b/TestAdapterTest/ReferenceCatchProject/ReferenceCatchProject.vcxproj
@@ -154,6 +154,11 @@
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="Tests.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="catch.runsettings">
+      <FileType>XML</FileType>
+    </None>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/TestAdapterTest/ReferenceCatchProject/ReferenceCatchProject.vcxproj.filters
+++ b/TestAdapterTest/ReferenceCatchProject/ReferenceCatchProject.vcxproj.filters
@@ -39,4 +39,7 @@
   <ItemGroup>
     <Text Include="README.md" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="catch.runsettings" />
+  </ItemGroup>
 </Project>

--- a/TestAdapterTest/ReferenceCatchProject/catch.runsettings
+++ b/TestAdapterTest/ReferenceCatchProject/catch.runsettings
@@ -1,12 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>  
-<RunSettings>
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings
 
   <!-- Adapter Specific sections -->
 
   <!-- Catch adapter -->
   <Catch>
     <!-- Regex that must match exe for tests to be searched from it. -->
-    <TestExeFilter>Reference</TestExeFilter>
+    <TestExeInclude>
+      <Regex>Reference</Regex>
+    </TestExeInclude>
+    <!-- If this regex matches, the exe is excluded even if it matches the include. -->
+    <TestExeExclude>
+      <Regex>Cheese</Regex>
+    </TestExeExclude>
   </Catch>
 
 </RunSettings>

--- a/TestAdapterTest/ReferenceCatchProject/catch.runsettings
+++ b/TestAdapterTest/ReferenceCatchProject/catch.runsettings
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>  
+<RunSettings>
+
+  <!-- Adapter Specific sections -->
+
+  <!-- Catch adapter -->
+  <Catch>
+    <!-- Regex that must match exe for tests to be searched from it. -->
+    <TestExeFilter>Reference</TestExeFilter>
+  </Catch>
+
+</RunSettings>

--- a/TestAdapterTest/ReferenceCatchProject/catch.runsettings
+++ b/TestAdapterTest/ReferenceCatchProject/catch.runsettings
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RunSettings
+<RunSettings>
 
   <!-- Adapter Specific sections -->
 
   <!-- Catch adapter -->
-  <Catch>
+  <CatchAdapter>
     <!-- Regex that must match exe for tests to be searched from it. -->
     <TestExeInclude>
       <Regex>Reference</Regex>
@@ -13,6 +13,6 @@
     <TestExeExclude>
       <Regex>Cheese</Regex>
     </TestExeExclude>
-  </Catch>
+  </CatchAdapter>
 
 </RunSettings>

--- a/TestAdapterTest/TestAdapterTest.csproj
+++ b/TestAdapterTest/TestAdapterTest.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Mocks\MockFrameworkHandle.cs" />
     <Compile Include="Mocks\MockMessageLogger.cs" />
     <Compile Include="Mocks\MockRunContext.cs" />
+    <Compile Include="Mocks\MockRunSettings.cs" />
     <Compile Include="Mocks\MockTestCaseDiscoverySink.cs" />
     <Compile Include="TestTestDiscoverer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/TestAdapterTest/TestAdapterTest.csproj
+++ b/TestAdapterTest/TestAdapterTest.csproj
@@ -78,6 +78,7 @@
     <Compile Include="TestTestDiscoverer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestTestExecutor.cs" />
+    <Compile Include="TestSettings.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TestAdapter\TestAdapter.csproj">

--- a/TestAdapterTest/TestSettings.cs
+++ b/TestAdapterTest/TestSettings.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestAdapter.Settings;
+
+namespace TestAdapterTest
+{
+    [TestClass]
+    public class TestSettings
+    {
+        [TestMethod]
+        public void EmptyExeFilterAcceptsAll()
+        {
+            CatchAdapterSettings settings = new CatchAdapterSettings();
+
+            Assert.IsTrue( settings.IncludeTestExe( "blaa" ) );
+            Assert.IsTrue( settings.IncludeTestExe( "Test.exe" ) );
+        }
+
+        [TestMethod]
+        public void IncludeExeFilterAcceptsOnlyMatching()
+        {
+            CatchAdapterSettings settings = new CatchAdapterSettings();
+            settings.TestExeInclude.Add( "blaa" );
+            settings.TestExeInclude.Add( @".*\.exe" );
+
+            Assert.IsTrue( settings.IncludeTestExe( "blaa" ) );
+            Assert.IsTrue( settings.IncludeTestExe( "Test.exe" ) );
+            Assert.IsFalse( settings.IncludeTestExe( "Hippopotamus" ) );
+        }
+
+        [TestMethod]
+        public void ExcludeExeFilterRejectsOnlyMatching()
+        {
+            CatchAdapterSettings settings = new CatchAdapterSettings();
+            settings.TestExeExclude.Add( "blaa" );
+            settings.TestExeExclude.Add( @".*\.exe" );
+
+            Assert.IsFalse( settings.IncludeTestExe( "blaa" ) );
+            Assert.IsFalse( settings.IncludeTestExe( "Test.exe" ) );
+            Assert.IsTrue( settings.IncludeTestExe( "Hippopotamus" ) );
+        }
+
+        [TestMethod]
+        public void IncludeExcludeTogether()
+        {
+            CatchAdapterSettings settings = new CatchAdapterSettings();
+            settings.TestExeInclude.Add( @".*\.exe" );
+            settings.TestExeExclude.Add( @"bl(aa|uu)" );
+            
+            Assert.IsTrue( settings.IncludeTestExe( "Test.exe" ) );
+            Assert.IsFalse( settings.IncludeTestExe( "Hippopotamus" ) );
+            Assert.IsFalse( settings.IncludeTestExe( "blaa.exe" ) );
+            Assert.IsFalse( settings.IncludeTestExe( "bluu.exe" ) );
+            Assert.IsTrue( settings.IncludeTestExe( "blii.exe" ) );
+        }
+    }
+}

--- a/TestAdapterTest/TestTestDiscoverer.cs
+++ b/TestAdapterTest/TestTestDiscoverer.cs
@@ -112,7 +112,7 @@ namespace TestAdapterTest
             var context = new MockDiscoveryContext();
             var provider = new CatchSettingsProvider();
             provider.Settings = new CatchAdapterSettings();
-            provider.Settings.TestExeFilter = @"ReferenceCatchProject\.exe";
+            provider.Settings.TestExeInclude.Add( @"ReferenceCatchProject\.exe" );
             context.MockSettings.Provider = provider;
 
             // Discover tests from the reference project and from anon-existent exe.
@@ -133,7 +133,8 @@ namespace TestAdapterTest
             testSink = new MockTestCaseDiscoverySink();
 
             // Filter all exes.
-            provider.Settings.TestExeFilter = "laksjdlkjalsdjasljd";
+            provider.Settings.TestExeInclude.Clear();
+            provider.Settings.TestExeInclude.Add( "laksjdlkjalsdjasljd" );
 
             // Discover again.
             discoverer.DiscoverTests( Common.ReferenceExeList,

--- a/TestAdapterTest/TestTestDiscoverer.cs
+++ b/TestAdapterTest/TestTestDiscoverer.cs
@@ -8,6 +8,7 @@ using TestAdapterTest.Mocks;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using TestAdapter.Settings;
 
 namespace TestAdapterTest
 {
@@ -97,6 +98,51 @@ namespace TestAdapterTest
             Assert.AreEqual( 2, tagsTest.Traits.Count() );
             Assert.IsTrue( tagsTest.Traits.Any( trait => trait.Name == "tag" ), traits );
             Assert.IsTrue( tagsTest.Traits.Any( trait => trait.Name == "neat" ), traits );
+        }
+
+        [TestMethod]
+        [DeploymentItem( Common.ReferenceExePath )]
+        // Tests that filters in runsettings are obeyed.
+        public void FiltersTestExecutables()
+        {
+            // Initialize a mock sink to keep track of the discovered tests.
+            MockTestCaseDiscoverySink testSink = new MockTestCaseDiscoverySink();
+
+            // Configure a mock context.
+            var context = new MockDiscoveryContext();
+            var provider = new CatchSettingsProvider();
+            provider.Settings = new CatchAdapterSettings();
+            provider.Settings.TestExeFilter = @"ReferenceCatchProject\.exe";
+            context.MockSettings.Provider = provider;
+
+            // Discover tests from the reference project and from anon-existent exe.
+            // The non-existent exe should get filtered out and cause no trouble.
+            TestDiscoverer discoverer = new TestDiscoverer();
+            List<string> exeList = new List<string>();
+            exeList.AddRange( Common.ReferenceExeList );
+            exeList.Add( "nonsense.exe" );
+            discoverer.DiscoverTests( Common.ReferenceExeList,
+                context,
+                new MockMessageLogger(),
+                testSink );
+
+            // There is a known number of test cases in the reference project.
+            Assert.AreEqual( testSink.Tests.Count, Common.ReferenceTestCount );
+
+            // Clear the sink.
+            testSink = new MockTestCaseDiscoverySink();
+
+            // Filter all exes.
+            provider.Settings.TestExeFilter = "laksjdlkjalsdjasljd";
+
+            // Discover again.
+            discoverer.DiscoverTests( Common.ReferenceExeList,
+                context,
+                new MockMessageLogger(),
+                testSink );
+
+            // There should be no tests, as nothing matches the filter.
+            Assert.AreEqual( testSink.Tests.Count, 0 );
         }
     }
 }


### PR DESCRIPTION
Currently, the adapter treats all executables as test executables. This is very inconvenient when the solution includes other executables, which get run on every test discovery round.

Implemented a setting for filtering the tests. Since this is the first setting for the adapter, had to initialize the infrastructure for reading settings from the runsettings file.

For example, you can tell the adapter to look for tests only in executables named `*.Test.exe` by activating this runsettings file:
```xml
<?xml version="1.0" encoding="utf-8"?>
<RunSettings>
  <CatchAdapter>
    <TestExeInclude>
      <Regex>.*\.Test\.exe</Regex>
    </TestExeInclude>
  </CatchAdapter>
</RunSettings>
```

There is a similar `TestExeExclude` element for excluding executables.