### PR TITLE
Enable "Debug Tests" action

### DIFF
--- a/TestAdapter/ProcessRunner.cs
+++ b/TestAdapter/ProcessRunner.cs
@@ -1,14 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
 
 namespace CatchTestAdapter
 {
     class ProcessRunner
     {
-        private IList<string> outputLines = new List<string>();
-        public ProcessRunner(string cmd, string args)
+        public static IList<string> RunProcess(string cmd, string args )
         {
-            var processStartInfo = new ProcessStartInfo(cmd, args)
+            List<string> outputLines = new List<string>();
+
+            var processStartInfo = new ProcessStartInfo( cmd, args )
             {
                 RedirectStandardOutput = true,
                 RedirectStandardError = false,
@@ -17,18 +21,39 @@ namespace CatchTestAdapter
                 WorkingDirectory = @"."
             };
 
-            Process process = Process.Start(processStartInfo);
-            process?.WaitForExit(500);
-            while (!process.StandardOutput.EndOfStream)
+            Process process = Process.Start( processStartInfo );
+            process?.WaitForExit( 500 );
+            while ( !process.StandardOutput.EndOfStream )
             {
                 string line = process.StandardOutput.ReadLine();
-                outputLines.Add(line);
+                outputLines.Add( line );
             }
 
             process?.Dispose();
 
+            return outputLines;
         }
 
-        public IList<string> Output { get { return outputLines; } }
+        public static IList<string> RunDebugProcess( IFrameworkHandle frameworkHandle, string cmd, string args )
+        {
+            List<string> outputLines = new List<string>();
+			var env = new Dictionary<string, string>();
+            var ourEnv = System.Environment.GetEnvironmentVariables();
+
+			foreach( string key in ourEnv.Keys )
+			{
+				env.Add( key, (string)ourEnv[ key ] );
+			}
+            int pid = frameworkHandle.LaunchProcessWithDebuggerAttached( cmd, @".", args, env );
+            using ( Process process = Process.GetProcessById( pid ) )
+            {
+                while ( process.StandardOutput.Peek() > 0 )
+                {
+                    outputLines.Add( process.StandardOutput.ReadLine() );
+                }
+            }
+
+            return outputLines;
+        }
     }
 }

--- a/TestAdapter/ProcessRunner.cs
+++ b/TestAdapter/ProcessRunner.cs
@@ -44,7 +44,7 @@ namespace CatchTestAdapter
 			{
 				env.Add( key, (string)ourEnv[ key ] );
 			}
-            int pid = frameworkHandle.LaunchProcessWithDebuggerAttached( cmd, @".", args, env );
+            int pid = frameworkHandle.LaunchProcessWithDebuggerAttached( cmd, System.Environment.CurrentDirectory, args, env );
             using ( Process process = Process.GetProcessById( pid ) )
             {
                 while ( process.StandardOutput.Peek() > 0 )

--- a/TestAdapter/TestDiscoverer.cs
+++ b/TestAdapter/TestDiscoverer.cs
@@ -39,9 +39,9 @@ namespace CatchTestAdapter
         public static IList<TestCase> CreateTestCases( string exeName )
         {
             var testCases = new List<TestCase>();
-            var p = new ProcessRunner(exeName, "--list-tests --verbosity high");
+            var output = ProcessRunner.RunProcess(exeName, "--list-tests --verbosity high");
 
-            foreach (var test in ParseListing( exeName, p.Output ) )
+            foreach (var test in ParseListing( exeName, output ) )
             {
                 testCases.Add( test );
             }

--- a/TestAdapter/TestExecutor.cs
+++ b/TestAdapter/TestExecutor.cs
@@ -28,24 +28,27 @@ namespace CatchTestAdapter
             // Load settings from the context.
             var settings = CatchSettingsProvider.LoadSettings( runContext.RunSettings );
 
-            frameworkHandle.SendMessage(TestMessageLevel.Informational, "RunTest with source " + sources.First());
-            try
+            frameworkHandle.SendMessage(TestMessageLevel.Informational, "CatchAdapter::RunTests... " );
+
+            // Run tests in all included executables.
+            foreach ( var exeName in sources.Where( name => settings.IncludeTestExe( name ) ) )
             {
-                // Run tests in all included executables.
-                foreach(var exeName in sources.Where(name => settings.IncludeTestExe(name) ) )
+                // Wrap execution in try to stop one executable's exceptions from stopping the others from being run.
+                try
                 {
+                    frameworkHandle.SendMessage( TestMessageLevel.Informational, "RunTest with source " + exeName );
                     var tests = TestDiscoverer.CreateTestCases( exeName );
                     RunTests( tests, runContext, frameworkHandle );
                 }
-            }
-            catch ( Microsoft.VisualStudio.TestPlatform.ObjectModel.TestPlatformException ex )
-            {
-                frameworkHandle.SendMessage( TestMessageLevel.Error, ex.Message );
-            }
-            catch ( Exception ex )
-            {
-                frameworkHandle.SendMessage( TestMessageLevel.Error, "Test platform exception: " + ex.Message );
-                frameworkHandle.SendMessage( TestMessageLevel.Error, "Test platform exception stack: " + ex.StackTrace );
+                catch ( Microsoft.VisualStudio.TestPlatform.ObjectModel.TestPlatformException ex )
+                {
+                    frameworkHandle.SendMessage( TestMessageLevel.Error, ex.Message );
+                }
+                catch ( Exception ex )
+                {
+                    frameworkHandle.SendMessage( TestMessageLevel.Error, "Test platform exception: " + ex.Message );
+                    frameworkHandle.SendMessage( TestMessageLevel.Error, "Test platform exception stack: " + ex.StackTrace );
+                }
             }
         }
 

--- a/TestAdapter/TestExecutor.cs
+++ b/TestAdapter/TestExecutor.cs
@@ -28,12 +28,24 @@ namespace CatchTestAdapter
             // Load settings from the context.
             var settings = CatchSettingsProvider.LoadSettings( runContext.RunSettings );
 
-            // Run tests in all included executables.
-            foreach(var exeName in sources.Where(name => settings.IncludeTestExe(name) ) )
+            frameworkHandle.SendMessage(TestMessageLevel.Informational, "RunTest with source " + sources.First());
+            try
             {
-                frameworkHandle.SendMessage( TestMessageLevel.Informational, "RunTest with source " + sources.First() );
-                var tests = TestDiscoverer.CreateTestCases( exeName );
-                RunTests(tests, runContext, frameworkHandle);
+                // Run tests in all included executables.
+                foreach(var exeName in sources.Where(name => settings.IncludeTestExe(name) ) )
+                {
+                    var tests = TestDiscoverer.CreateTestCases( exeName );
+                    RunTests( tests, runContext, frameworkHandle );
+                }
+            }
+            catch ( Microsoft.VisualStudio.TestPlatform.ObjectModel.TestPlatformException ex )
+            {
+                frameworkHandle.SendMessage( TestMessageLevel.Error, ex.Message );
+            }
+            catch ( Exception ex )
+            {
+                frameworkHandle.SendMessage( TestMessageLevel.Error, "Test platform exception: " + ex.Message );
+                frameworkHandle.SendMessage( TestMessageLevel.Error, "Test platform exception stack: " + ex.StackTrace );
             }
         }
 
@@ -142,15 +154,25 @@ namespace CatchTestAdapter
             
             // Write them to the input file for Catch runner
             System.IO.File.WriteAllText(CatchExe + ".testcases", listOfTestCases);
-            
+
             // Execute the tests
-            var output_text = new ProcessRunner(CatchExe, "-r xml --durations yes --input-file " + CatchExe + ".testcases");
+            IList<string> output_text;
+
+            string arguments = "-r xml --durations yes --input-file " + CatchExe + ".testcases";
+            if ( runContext.IsBeingDebugged )
+            {
+                output_text = ProcessRunner.RunDebugProcess( frameworkHandle, CatchExe, arguments );
+            }
+            else
+            {
+                output_text = ProcessRunner.RunProcess( CatchExe, arguments );
+            }
 
             timer.Stop();
             frameworkHandle.SendMessage(TestMessageLevel.Informational, "Overall time " + timer.Elapsed.ToString());
 
             // Output as a single string.
-            string output = output_text.Output.Aggregate("", (acc, add) => acc + add);
+            string output = output_text.Aggregate("", (acc, add) => acc + add);
 
             // Output as an XML document.
             XDocument doc = XDocument.Parse(output);

--- a/TestAdapter/TestExecutor.cs
+++ b/TestAdapter/TestExecutor.cs
@@ -40,14 +40,10 @@ namespace CatchTestAdapter
                     var tests = TestDiscoverer.CreateTestCases( exeName );
                     RunTests( tests, runContext, frameworkHandle );
                 }
-                catch ( Microsoft.VisualStudio.TestPlatform.ObjectModel.TestPlatformException ex )
-                {
-                    frameworkHandle.SendMessage( TestMessageLevel.Error, ex.Message );
-                }
                 catch ( Exception ex )
                 {
-                    frameworkHandle.SendMessage( TestMessageLevel.Error, "Test platform exception: " + ex.Message );
-                    frameworkHandle.SendMessage( TestMessageLevel.Error, "Test platform exception stack: " + ex.StackTrace );
+                    frameworkHandle.SendMessage( TestMessageLevel.Error, "Exception running tests: " + ex.Message );
+                    frameworkHandle.SendMessage( TestMessageLevel.Error, "Exception stack: " + ex.StackTrace );
                 }
             }
         }


### PR DESCRIPTION
The Visual Studio test framework has the option to debug tests directly from the test menu. This means you can set breakpoints in tests etc. Added support for this capability. It comes down to executing the test exe with `IFrameworkHandle.LaunchProcessWithDebuggerAttached` instead of launching it ourselves.