### PR TITLE
Fixed: Run tests fails when there are spaces in the test path

### DIFF
--- a/TestAdapter/TestExecutor.cs
+++ b/TestAdapter/TestExecutor.cs
@@ -138,7 +138,7 @@ namespace CatchTestAdapter
             // Execute the tests
             IList<string> output_text;
 
-            string arguments = "-r xml --durations yes --input-file " + CatchExe + ".testcases";
+            string arguments = "-r xml --durations yes --input-file \"" + CatchExe + ".testcases\"";
             if ( runContext.IsBeingDebugged )
             {
                 output_text = ProcessRunner.RunDebugProcess( frameworkHandle, CatchExe, arguments );

--- a/TestAdapter/TestExecutor.cs
+++ b/TestAdapter/TestExecutor.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using System.Xml.Linq;
+using System.IO;
 using System.Globalization;
 using System.Diagnostics;
 
@@ -131,14 +132,16 @@ namespace CatchTestAdapter
             
             // Get a list of all test case names
             var listOfTestCases = tests.Aggregate("", (acc, test) => acc + test.DisplayName + "\n");
-            
+
             // Write them to the input file for Catch runner
-            System.IO.File.WriteAllText(CatchExe + ".testcases", listOfTestCases);
+            string caseFile = "test.cases";
+            System.IO.File.WriteAllText(caseFile, listOfTestCases);
+            string originalDirectory = Directory.GetCurrentDirectory();
 
             // Execute the tests
             IList<string> output_text;
 
-            string arguments = "-r xml --durations yes --input-file \"" + CatchExe + ".testcases\"";
+            string arguments = "-r xml --durations yes --input-file=" + caseFile;
             if ( runContext.IsBeingDebugged )
             {
                 output_text = ProcessRunner.RunDebugProcess( frameworkHandle, CatchExe, arguments );
@@ -199,7 +202,7 @@ namespace CatchTestAdapter
                 frameworkHandle.RecordResult(testResult);
             }
             // Remove the temporary input file.
-            System.IO.File.Delete(CatchExe + ".testcases");
+            System.IO.File.Delete(caseFile);
         }
     }
 }

--- a/TestAdapterTest/TestTestExecutor.cs
+++ b/TestAdapterTest/TestTestExecutor.cs
@@ -7,6 +7,7 @@ using CatchTestAdapter;
 using TestAdapterTest.Mocks;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using System.IO;
 
 namespace TestAdapterTest
 {
@@ -23,6 +24,27 @@ namespace TestAdapterTest
             // Execute all tests.
             TestExecutor executor = new TestExecutor();
             executor.RunTests( Common.ReferenceExeList, new MockRunContext(), framework );
+
+            // Make sure we got results for all.
+            Assert.AreEqual( Common.ReferenceTestCount, framework.Results.Count );
+        }
+
+        [TestMethod]
+        public void TestExecutableWithSpaces()
+        {
+            // Copy the reference exe to a path with a space.
+            string spaceExe = Directory.GetCurrentDirectory() + "\\" + "Test Space.exe";
+            File.Copy( Common.ReferenceExePath, spaceExe );
+
+            // Set up a fake testing context.
+            var framework = new MockFrameworkHandle();
+
+            // Execute all tests.
+            TestExecutor executor = new TestExecutor();
+            executor.RunTests( new List<string>() { spaceExe }, new MockRunContext(), framework );
+
+            // Remove the copy.
+            File.Delete( spaceExe );
 
             // Make sure we got results for all.
             Assert.AreEqual( Common.ReferenceTestCount, framework.Results.Count );

--- a/TestAdapterTest/TestTestExecutor.cs
+++ b/TestAdapterTest/TestTestExecutor.cs
@@ -33,7 +33,9 @@ namespace TestAdapterTest
         public void TestExecutableWithSpaces()
         {
             // Copy the reference exe to a path with a space.
-            string spaceExe = Directory.GetCurrentDirectory() + "\\" + "Test Space.exe";
+            string spaceDir = Directory.GetCurrentDirectory() + "\\C++ Space - Test";
+            string spaceExe = spaceDir + "\\Test Space.exe";
+            Directory.CreateDirectory( spaceDir );
             File.Copy( Common.ReferenceExePath, spaceExe );
 
             // Set up a fake testing context.
@@ -45,6 +47,7 @@ namespace TestAdapterTest
 
             // Remove the copy.
             File.Delete( spaceExe );
+            Directory.Delete( spaceDir, true );
 
             // Make sure we got results for all.
             Assert.AreEqual( Common.ReferenceTestCount, framework.Results.Count );


### PR DESCRIPTION
The adapter failed when there was a space in the path to the list of tests to run. I tried to quote the path, but that didn't work consistently, so I just changed it to a hard-coded spaceless file name.

Also improved reporting on errors from Catch, while debugging this problem.