### PR TITLE
Fix tempfile locations

### DIFF
--- a/TestAdapter/ProcessRunner.cs
+++ b/TestAdapter/ProcessRunner.cs
@@ -10,7 +10,7 @@ namespace CatchTestAdapter
     /// <summary>
     /// Runs external processes.
     /// </summary>
-    class ProcessRunner
+    public class ProcessRunner
     {
         /// <summary>
         /// Execute a plain external process.
@@ -18,7 +18,7 @@ namespace CatchTestAdapter
         /// <param name="cmd">Path to executable.</param>
         /// <param name="args">Command line arguments.</param>
         /// <returns></returns>
-        public static IList<string> RunProcess(string cmd, string args )
+        public static IList<string> RunProcess(string cmd, string args, string workingDirectory )
         {
             // Start a new process.
             var processStartInfo = new ProcessStartInfo( cmd, args )
@@ -27,7 +27,7 @@ namespace CatchTestAdapter
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
-                WorkingDirectory = @"."
+                WorkingDirectory = workingDirectory
             };
 
             using ( Process process = Process.Start( processStartInfo ) )
@@ -43,7 +43,7 @@ namespace CatchTestAdapter
         /// <param name="cmd">The executable.</param>
         /// <param name="args">Command-line parameters.</param>
         /// <returns></returns>
-        public static IList<string> RunDebugProcess( IFrameworkHandle frameworkHandle, string cmd, string args )
+        public static IList<string> RunDebugProcess( IFrameworkHandle frameworkHandle, string cmd, string args, string workingDirectory )
         {
             // We cannot reliably capture the output of a process launched by the framework.
             // We store the output in a temp file instead.
@@ -53,7 +53,7 @@ namespace CatchTestAdapter
 
             // Tell the framework to run the process in a debugger.
             int pid = frameworkHandle.LaunchProcessWithDebuggerAttached(
-                cmd, System.Environment.CurrentDirectory,
+                cmd, workingDirectory,
                 argsWithOutFile, new Dictionary<string, string>() );
 
             // Wait for exit.
@@ -63,7 +63,8 @@ namespace CatchTestAdapter
             }
 
             // Get the output.
-            var outputLines = new List<string>( System.IO.File.ReadAllLines( outputFile ) );
+            var outputLines = new List<string>( System.IO.File.ReadAllLines( workingDirectory +
+				System.IO.Path.DirectorySeparatorChar + outputFile ) );
             System.IO.File.Delete( outputFile );
 
             return outputLines;

--- a/TestAdapter/TestDiscoverer.cs
+++ b/TestAdapter/TestDiscoverer.cs
@@ -46,7 +46,11 @@ namespace CatchTestAdapter
         public static IList<TestCase> CreateTestCases( string exeName )
         {
             var testCases = new List<TestCase>();
-            var output = ProcessRunner.RunProcess(exeName, "--list-tests --verbosity high");
+
+            // Use the directory of the executable as the working directory.
+            string workingDirectory = System.IO.Path.GetDirectoryName( exeName );
+
+            var output = ProcessRunner.RunProcess(exeName, "--list-tests --verbosity high", workingDirectory);
 
             foreach (var test in ParseListing( exeName, output ) )
             {

--- a/TestAdapter/TestExecutor.cs
+++ b/TestAdapter/TestExecutor.cs
@@ -133,9 +133,16 @@ namespace CatchTestAdapter
             // Get a list of all test case names
             var listOfTestCases = tests.Aggregate("", (acc, test) => acc + test.DisplayName + "\n");
 
+            // Use the directory of the executable as the working directory.
+            string workingDirectory = System.IO.Path.GetDirectoryName( CatchExe );
+            if ( workingDirectory == "" )
+                workingDirectory = ".";
+
             // Write them to the input file for Catch runner
             string caseFile = "test.cases";
-            System.IO.File.WriteAllText(caseFile, listOfTestCases);
+            System.IO.File.WriteAllText(
+				workingDirectory + System.IO.Path.DirectorySeparatorChar + caseFile,
+				listOfTestCases);
             string originalDirectory = Directory.GetCurrentDirectory();
 
             // Execute the tests
@@ -144,11 +151,11 @@ namespace CatchTestAdapter
             string arguments = "-r xml --durations yes --input-file=" + caseFile;
             if ( runContext.IsBeingDebugged )
             {
-                output_text = ProcessRunner.RunDebugProcess( frameworkHandle, CatchExe, arguments );
+                output_text = ProcessRunner.RunDebugProcess( frameworkHandle, CatchExe, arguments, workingDirectory );
             }
             else
             {
-                output_text = ProcessRunner.RunProcess( CatchExe, arguments );
+                output_text = ProcessRunner.RunProcess( CatchExe, arguments, workingDirectory );
             }
 
             timer.Stop();

--- a/TestAdapterTest/Mocks/MockFrameworkHandle.cs
+++ b/TestAdapterTest/Mocks/MockFrameworkHandle.cs
@@ -29,7 +29,8 @@ namespace TestAdapterTest.Mocks
 
         public int LaunchProcessWithDebuggerAttached( string filePath, string workingDirectory, string arguments, IDictionary<string, string> environmentVariables )
         {
-            throw new NotImplementedException();
+            CatchTestAdapter.ProcessRunner.RunProcess( filePath, arguments, workingDirectory );
+            return 0;
         }
 
         public void RecordAttachments( IList<AttachmentSet> attachmentSets )


### PR DESCRIPTION
#11, while fixing problems with spaces in folder names, stored the temporary files in the current working directory of the test framework, which is a bad choice, as it seems to be some random Visual Studio folder.

Changed it to store the temporary files in the folder where the test executable is.